### PR TITLE
protect numerator of Fraction to be integer

### DIFF
--- a/common/relmon.py
+++ b/common/relmon.py
@@ -108,7 +108,7 @@ class RelmonRequest():
     def is_download_ready(self):
         frac_ROOT = self.sample_fraction(
             ["ROOT", "downloaded"], ["NoDQMIO", "NoROOT"])
-        frac_threshold = fractions.Fraction(self.threshold, 100)
+        frac_threshold = fractions.Fraction( int(self.threshold), 100)
         return frac_ROOT >= frac_threshold
 
     def is_ROOT_100(self):


### PR DESCRIPTION
WARNING: this fix is already deployed manually in  
                   vocms085:/home/relmonsvc/relmonService
                   it should be removed before fetching the commit of this PR
-  fixes the error (*) due to the fact that the relmon report percentage gets stored into the data file as a string, leading to an error because " fractions.Fraction(self.threshold, 100) " does not accept an unicode/ascii as numerator
- the fix should be propagated upstream to store the 'fraction' as an integer into the data file (unless it's required to be a string elsewhere)
- what has introduced this error ? The service used to be able to run in June, while w/o this fix it's stuck any time the relmon reports are accessed looping inside the data file

(_)
Exception in thread Thread-7:
Traceback (most recent call last):
  File "/usr/lib64/python2.6/threading.py", line 532, in __bootstrap_inner
    self.run()
  File "/home/relmonsvc/relmonService/controller.py", line 32, in decorator
    return func(_args, **kwargs)
  File "/home/relmonsvc/relmonService/controller.py", line 64, in run
    if (not self._update_statuses()):
  File "/home/relmonsvc/relmonService/controller.py", line 106, in _update_statuses
    if (self.request.is_download_ready()):
  File "/home/relmonsvc/relmonService/common/relmon.py", line 111, in is_download_ready
    frac_threshold = fractions.Fraction(self.threshold, 100)
  File "/usr/lib64/python2.6/fractions.py", line 99, in __new__
    numerator = operator.index(numerator)
TypeError: 'unicode' object cannot be interpreted as an index
